### PR TITLE
feat(js): add jsdoc types

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": [
+    "./node_modules"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "jest": "^29.5.0",
         "moleculer": "^0.14.29",
         "node-polyglot": "^2.5.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1237,6 +1240,16 @@
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -6311,6 +6324,16 @@
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "moleculer-i18n",
   "version": "0.0.1",
   "description": "I18n package for Moleculer framework",
-  "main": "index.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "jest --coverage"
   },
@@ -38,5 +38,8 @@
       "/node_modules/",
       "/test/"
     ]
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.1"
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,14 @@
+/**
+ *
+ * @typedef {object} Translation
+ * @property {string} name
+ * @property {string} filepath
+ */
+
+/**
+ *
+ * @typedef {object} I18NSettings
+ * @property {string} dirName
+ * @property {string[]} languages
+ * @property {import("node-polyglot")} polyglot
+ */

--- a/test/base.spec.js
+++ b/test/base.spec.js
@@ -1,8 +1,8 @@
 const { ServiceBroker } = require("moleculer");
 const I18nMixin = require("../src");
 
-
 describe("Test with default settings", () => {
+    /** @type {ServiceBroker} */
     let broker;
 
     beforeAll(async () => {
@@ -10,6 +10,7 @@ describe("Test with default settings", () => {
 
         broker.createService({
             name: "greeter",
+            // @ts-expect-error mixin has correct type
             mixins: [I18nMixin],
             settings: {
                 i18n: {
@@ -20,6 +21,7 @@ describe("Test with default settings", () => {
             actions: {
                 welcome: {
                     handler(ctx) {
+                        // @ts-expect-error t function exists
                         return this.t(ctx, 'greeter.welcome.message');
                     }
                 },
@@ -29,6 +31,7 @@ describe("Test with default settings", () => {
                     },
                     handler(ctx) {
                         const { name } = ctx.params;
+                        // @ts-expect-error t function exists
                         return this.t(ctx, 'greeter.farewell', { name });
                     }
                 }
@@ -62,5 +65,4 @@ describe("Test with default settings", () => {
         const response = await broker.call('greeter.farewell', { name });
         expect(response).toEqual(`Good bye ${name}!`);
     });
-
 });


### PR DESCRIPTION
There are two small code changes at `readFilesSync` and `t` methods, but other changes are just type related.

- `readFilesSync`: *ext* and *stat* properties are not used, so they have been removed
- `t`: the condition became stricter

Added `jsoconfig.json` file to use strict types with javascript.